### PR TITLE
A-Assertions Branch PR

### DIFF
--- a/src/main/java/chattime/Chattime.java
+++ b/src/main/java/chattime/Chattime.java
@@ -33,9 +33,9 @@ public class Chattime {
         try {
             Command cmd = Parser.parse(input);
 
-            if (cmd != null) {
-                response = cmd.execute(ui, tasks, storage);
-            }
+            assert cmd != null : "Parsing process went wrong unexpectedly!";
+            response = cmd.execute(ui, tasks, storage);
+
         } catch (ChattimeException e) {
             return ui.printError(e.getMessage());
         }

--- a/src/main/java/chattime/storage/Storage.java
+++ b/src/main/java/chattime/storage/Storage.java
@@ -106,14 +106,17 @@ public class Storage {
 
                 switch (taskSplit[0]) {
                 case "T":
+                    assert taskSplit.length == 3 : "Todo task data error!";
                     inputTask = new Todo(taskSplit[2]);
                     break;
 
                 case "D":
+                    assert taskSplit.length == 5 : "Deadline task data error!";
                     inputTask = createDeadlineObject(taskSplit);
                     break;
 
                 case "E":
+                    assert taskSplit.length == 7 : "Deadline task data error!";
                     inputTask = createEventObject(taskSplit);
                     break;
 
@@ -237,6 +240,7 @@ public class Storage {
     private void writeToFile(String content, boolean append) {
         try {
             BufferedWriter writer = new BufferedWriter(new FileWriter(file, append));
+            assert !content.equals("") : "Storing empty data!";
             writer.write(content);
             writer.close();
 


### PR DESCRIPTION
`.chattime.Chattime` `getResponse(String input)`: need checking on the length of processed commands

Lengths of data are specified for different types of tasks. Processed commands should not be null.

Let's add assertions on lengths of loaded data according to types. Let's add assertions that cmd should not be null.

The lengths of loaded data and the parsed commands are not accessible by users, they need to have assertions to ensure that the programs are running in a normal and good condition.

Assertion error messages are added for clarification.